### PR TITLE
add_10

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 ## user_profile テーブル
 |Column|Type|Options|
 |------|----|-------|
-|self_introduction|text|-------|
+|self_introduction|text|optional: true|
 |last_name|string|null: false|
 |first_name|string|null: false|
 |last_name_kana|string|null: false|
@@ -40,7 +40,7 @@
 |birth_month|string|null: false|
 |birth_day|string|null: false|
 |phone_number|string|null: false|
-|optinal_phone_number|string||
+|optinal_phone_number|string|optional: true|
 |user_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :user

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5
 
-set :linked_files, %w{ config/credentials.yml.enc }
+set :linked_files, %w{config/master.key}
 
 # デプロイ処理が終わった後、Unicornを再起動するための記述
 after 'deploy:publishing', 'deploy:restart'
@@ -35,15 +35,3 @@ namespace :deploy do
   end
 end
 
-desc 'upload credentials.yml.enc'
-task :upload do
-  on roles(:app) do |host|
-    if test "[ ! -d #{shared_path}/config ]"
-      execute "mkdir -p #{shared_path}/config"
-    end
-    upload!('config/master.key', "#{shared_path}/config/credentials.yml.enc")
-  end
-end
-before :starting, 'deploy:upload'
-after :finishing, 'deploy:cleanup'
-end


### PR DESCRIPTION
#what
自動デプロイ導入（画像については開発環境ではローカルに保存されるように条件分岐）

#why
制作物をオープン化するため
また画像については条件分岐をしないとデプロイ担当者以外が設定できなくなるためです。