### PR TITLE
購入完了画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,4 @@
 @import "module/adress";
 @import "module/pay";
 @import "module/done";
+@import "done";

--- a/app/assets/stylesheets/done.scss
+++ b/app/assets/stylesheets/done.scss
@@ -1,0 +1,24 @@
+body{
+  height: 100%;
+}
+
+.parchase-done__main {
+  padding: 30px;
+  width: 700px;
+  height: 500px;
+  margin: 0 auto;
+  &__content{
+    text-align: center;
+    height: 100%;
+    &__text{
+      font-size: 40px;
+      line-height: 700%;
+    }
+    &__link{
+      font-size: 20px;
+    }
+    a{
+      color: rgb(128, 197, 230);
+    }
+  }
+}

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -30,8 +30,11 @@ class PurchaseController < ApplicationController
     end
   end
 
-  private
+  def done
+  end
 
+
+  private
   def redirect_to_credit_new
     @creditcard = Creditcard.find_by(user_id: 2)
     if @creditcard.blank?

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,0 +1,12 @@
+= render 'items/items-header'
+
+.parchase-done__main
+  .parchase-done__main__content
+    .parchase-done__main__content__text
+      %span 購入手続きが完了しました！
+
+    .parchase-done__main__content__link
+      = link_to root_path do
+        トップページへ戻る
+
+= render 'items/items-footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       collection do
         get 'buy'
         post 'pay'
+        get 'done'
       end
     end
     resources :comments, only: :create


### PR DESCRIPTION
#WHAT
購入完了画面の実装
<img width="1440" alt="スクリーンショット 2020-01-09 12 42 26" src="https://user-images.githubusercontent.com/57927347/72036366-e9ce6400-32dd-11ea-993b-1160c8f1be2f.png">

#WHY
ユーザーが購入手続き完了の確認をできるようにするため