### PR TITLE
購入、商品詳細の画面のビュー調整

### DIFF
--- a/app/assets/stylesheets/items/_buy.scss
+++ b/app/assets/stylesheets/items/_buy.scss
@@ -82,9 +82,11 @@
           }
     
           &__logo{
-            width: 26px;
-            height: 20px;
             margin-bottom: 20px;
+            &--image{
+              width: 26px;
+              height: 20px;
+            }
           }
     
           a{

--- a/app/views/creditcards/show.html.haml
+++ b/app/views/creditcards/show.html.haml
@@ -13,7 +13,24 @@
             %ul.single__inner__list
               %li
                 .single__inner__list__content
-                  = image_tag "/images/visa.svg", height: 15, width: 49
+                  -if @default_card_information.brand == "Visa"
+                    = image_tag "/images/visa.svg", height: 15, width: 49
+                  
+                  -elsif @default_card_information.brand == "MasterCard"
+                    = image_tag "/images/master-card.svg", height: 15, width: 49
+
+                  -elsif @default_card_information.brand == "JCB"
+                    = image_tag "/images/jcb.svg", height: 15, width: 49
+
+                  -elsif @default_card_information.brand == "American Express"
+                    = image_tag "/images/american_express.svg", height: 15, width: 49
+
+                  -elsif @default_card_information.brand == "Diners Club"
+                    = image_tag "/images/dinersclub.svg", height: 15, width: 49
+
+                  -elsif @default_card_information.brand == "Discover"
+                    = image_tag "/images/discover.svg", height: 15, width: 49
+
                   .single__inner__list__num
                     = "**** **** **** " + @default_card_information.last4
                   .single__inner__list__num

--- a/app/views/purchase/buy.html.haml
+++ b/app/views/purchase/buy.html.haml
@@ -53,7 +53,25 @@
               = exp_month + " / " + exp_year
 
           .item-buy-contents__main__buy-item__box__pay-method__logo
-            = image_tag src='/images/fmarket_logo_red.svg', class: ".item-buy-contents__main__buy-item__box__pay-method__logo--image"
+            -if @default_card_information.brand == "Visa"
+              = image_tag "/images/visa.svg", height: 15, width: 49, class: "item-buy-contents__main__buy-item__box__pay-method__logo--image"
+            
+            -elsif @default_card_information.brand == "MasterCard"
+              = image_tag "/images/master-card.svg", height: 15, width: 49, class: "item-buy-contents__main__buy-item__box__pay-method__logo--image"
+
+            -elsif @default_card_information.brand == "JCB"
+              = image_tag "/images/jcb.svg", height: 15, width: 49, class: "item-buy-contents__main__buy-item__box__pay-method__logo--image"
+
+            -elsif @default_card_information.brand == "American Express"
+              = image_tag "/images/american_express.svg", height: 15, width: 49, class: "item-buy-contents__main__buy-item__box__pay-method__logo--image"
+
+            -elsif @default_card_information.brand == "Diners Club"
+              = image_tag "/images/dinersclub.svg", height: 15, width: 49, class: "item-buy-contents__main__buy-item__box__pay-method__logo--image"
+
+            -elsif @default_card_information.brand == "Discover"
+              = image_tag "/images/discover.svg", height: 15, width: 49, class: "item-buy-contents__main__buy-item__box__pay-method__logo--image"
+
+            
 
         .item-buy-contents__main__buy-item__box__area
           .item-buy-contents__main__buy-item__box__area--text


### PR DESCRIPTION
#WHAT
クレジットカードのブランドに応じて、ロゴ画像が切り替わるように調整

#WHY
見栄えのため